### PR TITLE
Fix the pip version as 0.6.3 for aws_role_credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install virtualenv
 RUN virtualenv /okta_venv \
         && source /okta_venv/bin/activate \
         && pip install \
-            "aws_role_credentials>=0.6.3" \
+            "aws_role_credentials==0.6.3" \
             "oktaauth>=0.2" \
             "awscli>=1.15"
 


### PR DESCRIPTION
okta_aws_login.sh failed with error : Error authorising with okta: [Errno 32] Broken pipe
Fix checked with pgillard@thoughtworks.com